### PR TITLE
Fix for Ghostscript >=9.50

### DIFF
--- a/src/PDFLib.php
+++ b/src/PDFLib.php
@@ -153,7 +153,12 @@ class PDFLib{
             if($this->gs_command == "gswin32c.exe" || $this->gs_command == "gswin64c.exe"){
                 $this->pdf_path = str_replace('\\', '/', $this->pdf_path);
             }
-            $pages = $this->executeGS('-q -dNODISPLAY -c "('.$this->pdf_path.') (r) file runpdfbegin pdfpagecount = quit"',true);
+            if($gs_version >= 9.50){
+                $pages = $this->executeGS('-q -dNOSAFER -c "('.$this->pdf_path.') (r) file runpdfbegin pdfpagecount = quit"',true);
+            }
+            else {
+                $pages = $this->executeGS('-q -dNODISPLAY -c "('.$this->pdf_path.') (r) file runpdfbegin pdfpagecount = quit"',true);
+            }
             $this->number_of_pages = intval($pages);
         }
         return $this->number_of_pages;


### PR DESCRIPTION
Fix for "permission denied" error with Ghostscript >=9.50